### PR TITLE
Update gradle to 7.3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import org.gradle.util.DistributionLocator
+import org.gradle.util.GradleVersion
+
 plugins {
     // https://docs.gradle.org/current/userguide/java_library_plugin.html
     id "java-library"
@@ -47,6 +50,19 @@ java {
     withSourcesJar()
 }
 
+wrapper {
+    distributionType = 'ALL'
+    doLast {
+        final DistributionLocator locator = new DistributionLocator()
+        final GradleVersion version = GradleVersion.version(wrapper.gradleVersion)
+        final URI distributionUri = locator.getDistributionFor(version, wrapper.distributionType.name().toLowerCase(Locale.ENGLISH))
+        final URI sha256Uri = new URI(distributionUri.toString() + ".sha256")
+        final String sha256Sum = new String(sha256Uri.toURL().bytes)
+        wrapper.getPropertiesFile() << "distributionSha256Sum=${sha256Sum}\n"
+        println "Added checksum to wrapper properties"
+    }
+}
+
 compileJava {
     options.compilerArgs = ["-Xlint:all", "-Werror"]
 }
@@ -56,7 +72,7 @@ javadoc {
 }
 
 jacoco {
-    toolVersion = "0.8.5"
+    toolVersion = "0.8.7"
 }
 
 repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=b13f5d97f08000996bf12d9dd70af3f2c6b694c2c663ab1b545e9695562ad1ee
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=c9490e938b221daf0094982288e4038deed954a3f12fb54cbf270ddf4e37d879


### PR DESCRIPTION
Update gradle to 7.3.3 and make it compilable with jdk17

Also there is a small improvement to wrapper which simplifies gradle update next time.

E.g. by default `./gradlew wrapper --gradle-version <new_version>` will set distribution as `bin` and will remove checksum
After this PR it will set distribution to `all` and renew checksum