### PR TITLE
Clearing record grouper on exceptions to avoid duplicates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ ext {
     junitVersion = "5.9.1"
     testcontainersVersion = "1.17.5"
     localstackVersion = "0.2.21"
+    wireMockVersion = "2.35.0"
     mockitoVersion = "4.8.1"
 }
 
@@ -157,6 +158,7 @@ dependencies {
     integrationTestImplementation "cloud.localstack:localstack-utils:$localstackVersion"
     integrationTestImplementation "org.testcontainers:junit-jupiter:$testcontainersVersion"
     integrationTestImplementation "org.testcontainers:kafka:$testcontainersVersion" // this is not Kafka version
+    integrationTestImplementation "com.github.tomakehurst:wiremock-jre8:$wireMockVersion"
 
     integrationTestImplementation("io.confluent:kafka-avro-serializer:$confluentPlatformVersion") {
         exclude group: "org.apache.kafka", module: "kafka-clients"

--- a/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
@@ -119,8 +119,11 @@ public class S3SinkTask extends SinkTask {
 
     @Override
     public void flush(final Map<TopicPartition, OffsetAndMetadata> offsets) {
-        recordGrouper.records().forEach(this::flushFile);
-        recordGrouper.clear();
+        try {
+            recordGrouper.records().forEach(this::flushFile);
+        } finally {
+            recordGrouper.clear();
+        }
     }
 
     private void flushFile(final String filename, final List<SinkRecord> records) {

--- a/src/test/java/io/aiven/kafka/connect/s3/testutils/BucketAccessor.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/testutils/BucketAccessor.java
@@ -121,6 +121,11 @@ public class BucketAccessor {
         }
     }
 
+    public final List<String> listObjects() {
+        return s3.listObjects(bucketName).getObjectSummaries().stream().map(S3ObjectSummary::getKey)
+            .collect(Collectors.toList());
+    }
+
     private InputStream getDecompressedStream(final InputStream inputStream, final String compression)
         throws IOException {
         Objects.requireNonNull(inputStream, "inputStream cannot be null");


### PR DESCRIPTION
When the exception is thrown during flush(e.g. network error), Kafka connects rewinds the offsets to last committed and tries to commit current offsets once again. This causes duplicates in the connector since the offsets are now cached in record grouper. Cleaning the record grouper on exception solves the issues. 