### PR TITLE
fix(test): enable integration tests

### DIFF
--- a/.github/workflows/main_push_and_pull_request_workflow.yml
+++ b/.github/workflows/main_push_and_pull_request_workflow.yml
@@ -10,17 +10,17 @@ jobs:
     strategy:
       matrix:
         java-version: [11, 17]
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest]
     name: Build on ${{ matrix.runs-on }} with jdk ${{ matrix.java-version }}
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.5.2
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.11.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: "temurin"
           cache: gradle
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build integrationTest

--- a/build.gradle
+++ b/build.gradle
@@ -151,6 +151,7 @@ dependencies {
     integrationTestImplementation "cloud.localstack:localstack-utils:$localstackVersion"
     integrationTestImplementation "org.testcontainers:junit-jupiter:$testcontainersVersion"
     integrationTestImplementation "org.testcontainers:kafka:$testcontainersVersion" // this is not Kafka version
+    integrationTestImplementation "org.testcontainers:localstack:$testcontainersVersion"
     integrationTestImplementation "com.github.tomakehurst:wiremock-jre8:$wireMockVersion"
 
     integrationTestImplementation("io.confluent:kafka-avro-serializer:$confluentPlatformVersion") {

--- a/build.gradle
+++ b/build.gradle
@@ -205,6 +205,7 @@ dependencies {
 
     // Make test utils from 'test' available in 'integration-test'
     integrationTestImplementation sourceSets.test.output
+    integrationTestImplementation "org.awaitility:awaitility:4.2.0"
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }
@@ -220,7 +221,8 @@ task integrationTest(type: Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
 
-    dependsOn test, distTar
+    dependsOn distTar
+    shouldRunAfter test
 
     useJUnitPlatform()
 

--- a/src/integration-test/java/io/aiven/kafka/connect/AvroIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/AvroIntegrationTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -78,7 +77,6 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
     private static final String TEST_BUCKET_NAME = "test-bucket0";
 
     private static final String CONNECTOR_NAME = "aiven-s3-sink-connector";
-    private static final String TEST_TOPIC_0 = "test-topic-0";
     private static final String COMMON_PREFIX = "s3-connector-for-apache-kafka-test-";
     private static final int OFFSET_FLUSH_INTERVAL_MS = 5000;
 
@@ -88,9 +86,9 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
     private static File pluginDir;
 
     @Container
-    private final KafkaContainer kafka = createKafkaContainer();
+    private static final KafkaContainer KAFKA = KafkaIntegrationBase.createKafkaContainer();
     @Container
-    private final SchemaRegistryContainer schemaRegistry = new SchemaRegistryContainer(kafka);
+    private static final SchemaRegistryContainer SCHEMA_REGISTRY = new SchemaRegistryContainer(KAFKA);
     private AdminClient adminClient;
     private KafkaProducer<String, GenericRecord> producer;
     private ConnectRunner connectRunner;
@@ -110,17 +108,18 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
 
         pluginDir = KafkaIntegrationBase.getPluginDir();
         KafkaIntegrationBase.extractConnectorPlugin(pluginDir);
+
+        KafkaIntegrationBase.waitForRunningContainer(KAFKA);
     }
 
     @BeforeEach
     void setUp() throws ExecutionException, InterruptedException {
-        adminClient = newAdminClient(kafka);
-        producer = newProducer(kafka);
+        adminClient = newAdminClient(KAFKA);
+        producer = newProducer(KAFKA);
 
-        final NewTopic newTopic0 = new NewTopic(TEST_TOPIC_0, 4, (short) 1);
-        adminClient.createTopics(Arrays.asList(newTopic0)).all().get();
+        KafkaIntegrationBase.recreateTopics(adminClient);
 
-        connectRunner = newConnectRunner(kafka, pluginDir, OFFSET_FLUSH_INTERVAL_MS);
+        connectRunner = newConnectRunner(KAFKA, pluginDir, OFFSET_FLUSH_INTERVAL_MS);
         connectRunner.start();
     }
 
@@ -278,7 +277,7 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
             "io.confluent.kafka.serializers.KafkaAvroSerializer");
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
             "io.confluent.kafka.serializers.KafkaAvroSerializer");
-        producerProps.put("schema.registry.url", schemaRegistry.getSchemaRegistryUrl());
+        producerProps.put("schema.registry.url", SCHEMA_REGISTRY.getSchemaRegistryUrl());
         return new KafkaProducer<>(producerProps);
     }
 
@@ -296,9 +295,9 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
         final Map<String, String> config = new HashMap<>();
         config.put("name", connectorName);
         config.put("key.converter", "io.confluent.connect.avro.AvroConverter");
-        config.put("key.converter.schema.registry.url", schemaRegistry.getSchemaRegistryUrl());
+        config.put("key.converter.schema.registry.url", SCHEMA_REGISTRY.getSchemaRegistryUrl());
         config.put("value.converter", "io.confluent.connect.avro.AvroConverter");
-        config.put("value.converter.schema.registry.url", schemaRegistry.getSchemaRegistryUrl());
+        config.put("value.converter.schema.registry.url", SCHEMA_REGISTRY.getSchemaRegistryUrl());
         config.put("tasks.max", "1");
         return config;
     }
@@ -311,8 +310,8 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
         config.put("aws.s3.bucket.name", TEST_BUCKET_NAME);
         config.put("aws.s3.prefix", s3Prefix);
         config.put("topics", TEST_TOPIC_0);
-        config.put("key.converter.schema.registry.url", schemaRegistry.getSchemaRegistryUrl());
-        config.put("value.converter.schema.registry.url", schemaRegistry.getSchemaRegistryUrl());
+        config.put("key.converter.schema.registry.url", SCHEMA_REGISTRY.getSchemaRegistryUrl());
+        config.put("value.converter.schema.registry.url", SCHEMA_REGISTRY.getSchemaRegistryUrl());
         config.put("tasks.max", "1");
         return config;
     }

--- a/src/integration-test/java/io/aiven/kafka/connect/AvroIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/AvroIntegrationTest.java
@@ -40,10 +40,6 @@ import io.aiven.kafka.connect.s3.AivenKafkaConnectS3SinkConnector;
 import io.aiven.kafka.connect.s3.SchemaRegistryContainer;
 import io.aiven.kafka.connect.s3.testutils.BucketAccessor;
 
-import cloud.localstack.Localstack;
-import cloud.localstack.awssdkv1.TestUtils;
-import cloud.localstack.docker.LocalstackDockerExtension;
-import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 import com.amazonaws.services.s3.AmazonS3;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
@@ -57,21 +53,20 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(LocalstackDockerExtension.class)
-@LocalstackDockerProperties(services = {"s3"})
 @Testcontainers
-public class AvroIntegrationTest implements KafkaIntegrationBase {
+public class AvroIntegrationTest implements IntegrationBase {
     private static final String S3_ACCESS_KEY_ID = "test-key-id0";
     private static final String S3_SECRET_ACCESS_KEY = "test_secret_key0";
     private static final String TEST_BUCKET_NAME = "test-bucket0";
@@ -86,7 +81,9 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
     private static File pluginDir;
 
     @Container
-    private static final KafkaContainer KAFKA = KafkaIntegrationBase.createKafkaContainer();
+    public static final LocalStackContainer LOCALSTACK = IntegrationBase.createS3Container();
+    @Container
+    private static final KafkaContainer KAFKA = IntegrationBase.createKafkaContainer();
     @Container
     private static final SchemaRegistryContainer SCHEMA_REGISTRY = new SchemaRegistryContainer(KAFKA);
     private AdminClient adminClient;
@@ -101,23 +98,25 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
         s3Prefix = COMMON_PREFIX
             + ZonedDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + "/";
 
-        final AmazonS3 s3 = TestUtils.getClientS3();
-        s3Endpoint = Localstack.INSTANCE.getEndpointS3();
+        final AmazonS3 s3 = IntegrationBase.createS3Client(LOCALSTACK);
+        s3Endpoint = LOCALSTACK.getEndpoint().toString();
         testBucketAccessor = new BucketAccessor(s3, TEST_BUCKET_NAME);
         testBucketAccessor.createBucket();
 
-        pluginDir = KafkaIntegrationBase.getPluginDir();
-        KafkaIntegrationBase.extractConnectorPlugin(pluginDir);
+        pluginDir = IntegrationBase.getPluginDir();
+        IntegrationBase.extractConnectorPlugin(pluginDir);
 
-        KafkaIntegrationBase.waitForRunningContainer(KAFKA);
+        IntegrationBase.waitForRunningContainer(KAFKA);
     }
 
-    @BeforeEach
-    void setUp() throws ExecutionException, InterruptedException {
-        adminClient = newAdminClient(KAFKA);
-        producer = newProducer(KAFKA);
 
-        KafkaIntegrationBase.recreateTopics(adminClient);
+    @BeforeEach
+    void setUp(final TestInfo testInfo) throws ExecutionException, InterruptedException {
+        adminClient = newAdminClient(KAFKA);
+        producer = newProducer();
+
+        final var topicName = IntegrationBase.topicName(testInfo);
+        IntegrationBase.recreateTopics(adminClient, List.of(topicName));
 
         connectRunner = newConnectRunner(KAFKA, pluginDir, OFFSET_FLUSH_INTERVAL_MS);
         connectRunner.start();
@@ -140,9 +139,10 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
 
     @ParameterizedTest
     @MethodSource("compressionAndCodecTestParameters")
-    void avroOutput(final String avroCodec, final String compression)
-            throws ExecutionException, InterruptedException, IOException {
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME));
+    void avroOutput(final String avroCodec, final String compression, final TestInfo testInfo)
+        throws ExecutionException, InterruptedException, IOException {
+        final var topicName = IntegrationBase.topicName(testInfo);
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME), topicName);
         connectorConfig.put("file.compression.type", compression);
         connectorConfig.put("format.output.fields", "key,value");
         connectorConfig.put("format.output.type", "avro");
@@ -150,15 +150,15 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
         connectRunner.createConnector(connectorConfig);
 
         final int recordCountPerPartition = 10;
-        produceRecords(recordCountPerPartition);
+        produceRecords(recordCountPerPartition, topicName);
 
         waitForConnectToFinishProcessing();
 
         final List<String> expectedBlobs = Arrays.asList(
-            getAvroBlobName(0, 0, compression),
-            getAvroBlobName(1, 0, compression),
-            getAvroBlobName(2, 0, compression),
-            getAvroBlobName(3, 0, compression));
+            getAvroBlobName(topicName, 0, 0, compression),
+            getAvroBlobName(topicName, 1, 0, compression),
+            getAvroBlobName(topicName, 2, 0, compression),
+            getAvroBlobName(topicName, 3, 0, compression));
         for (final String blobName : expectedBlobs) {
             assertTrue(testBucketAccessor.doesObjectExist(blobName));
         }
@@ -181,7 +181,7 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
         int cnt = 0;
         for (int i = 0; i < recordCountPerPartition; i++) {
             for (int partition = 0; partition < 4; partition++) {
-                final String blobName = getAvroBlobName(partition, 0, compression);
+                final String blobName = getAvroBlobName(topicName, partition, 0, compression);
                 final Schema gcsOutputAvroSchema = gcsOutputAvroSchemas.get(blobName);
                 final GenericData.Record expectedRecord = new GenericData.Record(gcsOutputAvroSchema);
                 expectedRecord.put("key", new Utf8("key-" + cnt));
@@ -198,8 +198,10 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
     }
 
     @Test
-    final void jsonlAvroOutputTest() throws ExecutionException, InterruptedException, IOException {
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME));
+    final void jsonlAvroOutputTest(final TestInfo testInfo)
+        throws ExecutionException, InterruptedException, IOException {
+        final var topicName = IntegrationBase.topicName(testInfo);
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME), topicName);
         final String compression = "none";
         final String contentType = "jsonl";
         connectorConfig.put("format.output.fields", "key,value");
@@ -212,14 +214,14 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
         connectRunner.createConnector(connectorConfig);
 
         final int recordCountPerPartition = 10;
-        produceRecords(recordCountPerPartition);
+        produceRecords(recordCountPerPartition, topicName);
         waitForConnectToFinishProcessing();
 
         final List<String> expectedBlobs = Arrays.asList(
-            getBlobName(0, 0, compression),
-            getBlobName(1, 0, compression),
-            getBlobName(2, 0, compression),
-            getBlobName(3, 0, compression));
+            getBlobName(topicName, 0, 0, compression),
+            getBlobName(topicName, 1, 0, compression),
+            getBlobName(topicName, 2, 0, compression),
+            getBlobName(topicName, 3, 0, compression));
         for (final String blobName : expectedBlobs) {
             assertTrue(testBucketAccessor.doesObjectExist(blobName));
         }
@@ -237,7 +239,7 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
                 final String value = "{" + "\"name\":\"user-" + cnt + "\"}";
                 cnt += 1;
 
-                final String blobName = getBlobName(partition, 0, "none");
+                final String blobName = getBlobName(topicName, partition, 0, "none");
                 final String actualLine = blobContents.get(blobName).get(i);
                 final String expectedLine = "{\"value\":" + value + ",\"key\":\"" + key + "\"}";
                 assertEquals(expectedLine, actualLine);
@@ -250,7 +252,8 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
         Thread.sleep(OFFSET_FLUSH_INTERVAL_MS * 2);
     }
 
-    private void produceRecords(final int recordCountPerPartition) throws ExecutionException, InterruptedException {
+    private void produceRecords(final int recordCountPerPartition, final String topicName)
+        throws ExecutionException, InterruptedException {
         final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
         int cnt = 0;
         for (int i = 0; i < recordCountPerPartition; i++) {
@@ -260,7 +263,7 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
                 value.put("name", "user-" + cnt);
                 cnt += 1;
 
-                sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, partition, key, value));
+                sendFutures.add(sendMessageAsync(producer, topicName, partition, key, value));
             }
         }
         producer.flush();
@@ -269,10 +272,9 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
         }
     }
 
-    private KafkaProducer<String, GenericRecord> newProducer(final KafkaContainer kafka) {
-
+    private KafkaProducer<String, GenericRecord> newProducer() {
         final Map<String, Object> producerProps = new HashMap<>();
-        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
             "io.confluent.kafka.serializers.KafkaAvroSerializer");
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
@@ -302,28 +304,30 @@ public class AvroIntegrationTest implements KafkaIntegrationBase {
         return config;
     }
 
-    private Map<String, String> awsSpecificConfig(final Map<String, String> config) {
+    private Map<String, String> awsSpecificConfig(final Map<String, String> config, final String topicName) {
         config.put("connector.class", AivenKafkaConnectS3SinkConnector.class.getName());
         config.put("aws.access.key.id", S3_ACCESS_KEY_ID);
         config.put("aws.secret.access.key", S3_SECRET_ACCESS_KEY);
         config.put("aws.s3.endpoint", s3Endpoint);
         config.put("aws.s3.bucket.name", TEST_BUCKET_NAME);
         config.put("aws.s3.prefix", s3Prefix);
-        config.put("topics", TEST_TOPIC_0);
+        config.put("topics", topicName);
         config.put("key.converter.schema.registry.url", SCHEMA_REGISTRY.getSchemaRegistryUrl());
         config.put("value.converter.schema.registry.url", SCHEMA_REGISTRY.getSchemaRegistryUrl());
         config.put("tasks.max", "1");
         return config;
     }
 
-    private String getAvroBlobName(final int partition, final int startOffset, final String compression) {
-        final String result = String.format("%s%s-%d-%020d.avro", s3Prefix, TEST_TOPIC_0, partition, startOffset);
-        return result  + CompressionType.forName(compression).extension();
+    private String getAvroBlobName(final String topicName, final int partition, final int startOffset,
+                                   final String compression) {
+        final String result = String.format("%s%s-%d-%020d.avro", s3Prefix, topicName, partition, startOffset);
+        return result + CompressionType.forName(compression).extension();
     }
 
     // WARN: different from GCS
-    private String getBlobName(final int partition, final int startOffset, final String compression) {
-        final String result = String.format("%s%s-%d-%020d", s3Prefix, TEST_TOPIC_0, partition, startOffset);
+    private String getBlobName(final String topicName, final int partition, final int startOffset,
+                               final String compression) {
+        final String result = String.format("%s%s-%d-%020d", s3Prefix, topicName, partition, startOffset);
         return result + CompressionType.forName(compression).extension();
     }
 }

--- a/src/integration-test/java/io/aiven/kafka/connect/AvroParquetIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/AvroParquetIntegrationTest.java
@@ -42,10 +42,6 @@ import io.aiven.kafka.connect.s3.AivenKafkaConnectS3SinkConnector;
 import io.aiven.kafka.connect.s3.SchemaRegistryContainer;
 import io.aiven.kafka.connect.s3.testutils.BucketAccessor;
 
-import cloud.localstack.Localstack;
-import cloud.localstack.awssdkv1.TestUtils;
-import cloud.localstack.docker.LocalstackDockerExtension;
-import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 import com.amazonaws.services.s3.AmazonS3;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
@@ -55,9 +51,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -67,10 +64,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(LocalstackDockerExtension.class)
-@LocalstackDockerProperties(services = {"s3"})
 @Testcontainers
-class AvroParquetIntegrationTest implements KafkaIntegrationBase {
+class AvroParquetIntegrationTest implements IntegrationBase {
     private static final String S3_ACCESS_KEY_ID = "test-key-id0";
     private static final String S3_SECRET_ACCESS_KEY = "test_secret_key0";
     private static final String TEST_BUCKET_NAME = "test-bucket0";
@@ -85,7 +80,9 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
     private static File pluginDir;
 
     @Container
-    private static final KafkaContainer KAFKA = KafkaIntegrationBase.createKafkaContainer();
+    public static final LocalStackContainer LOCALSTACK = IntegrationBase.createS3Container();
+    @Container
+    private static final KafkaContainer KAFKA = IntegrationBase.createKafkaContainer();
     @Container
     private static final SchemaRegistryContainer SCHEMA_REGISTRY = new SchemaRegistryContainer(KAFKA);
     private AdminClient adminClient;
@@ -95,25 +92,26 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
     @BeforeAll
     static void setUpAll() throws IOException, InterruptedException {
         s3Prefix = COMMON_PREFIX
-                + ZonedDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + "/";
+            + ZonedDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + "/";
 
-        final AmazonS3 s3 = TestUtils.getClientS3();
-        s3Endpoint = Localstack.INSTANCE.getEndpointS3();
+        final AmazonS3 s3 = IntegrationBase.createS3Client(LOCALSTACK);
+        s3Endpoint = LOCALSTACK.getEndpoint().toString();
         testBucketAccessor = new BucketAccessor(s3, TEST_BUCKET_NAME);
         testBucketAccessor.createBucket();
 
-        pluginDir = KafkaIntegrationBase.getPluginDir();
-        KafkaIntegrationBase.extractConnectorPlugin(pluginDir);
+        pluginDir = IntegrationBase.getPluginDir();
+        IntegrationBase.extractConnectorPlugin(pluginDir);
 
-        KafkaIntegrationBase.waitForRunningContainer(KAFKA);
+        IntegrationBase.waitForRunningContainer(KAFKA);
     }
 
     @BeforeEach
-    void setUp() throws ExecutionException, InterruptedException {
+    void setUp(final TestInfo testInfo) throws ExecutionException, InterruptedException {
         adminClient = newAdminClient(KAFKA);
-        producer = newProducer(KAFKA);
+        producer = newProducer();
 
-        KafkaIntegrationBase.recreateTopics(adminClient);
+        final var topicName = IntegrationBase.topicName(testInfo);
+        IntegrationBase.recreateTopics(adminClient, List.of(topicName));
 
         connectRunner = newConnectRunner(KAFKA, pluginDir, OFFSET_FLUSH_INTERVAL_MS);
         connectRunner.start();
@@ -129,16 +127,17 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
     }
 
     @Test
-    final void allOutputFields(@TempDir final Path tmpDir)
-            throws ExecutionException, InterruptedException, IOException {
+    final void allOutputFields(@TempDir final Path tmpDir, final TestInfo testInfo)
+        throws ExecutionException, InterruptedException, IOException {
+        final var topicName = IntegrationBase.topicName(testInfo);
         final String compression = "none";
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression));
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression), topicName);
         connectorConfig.put("format.output.fields", "key,value,offset,timestamp,headers");
         connectorConfig.put("format.output.fields.value.encoding", "none");
         connectRunner.createConnector(connectorConfig);
 
         final Schema valueSchema =
-                SchemaBuilder.record("value")
+            SchemaBuilder.record("value")
                         .fields()
                         .name("name").type().stringType().noDefault()
                         .name("value").type().stringType().noDefault()
@@ -153,7 +152,7 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
                 value.put("name", "user-" + cnt);
                 value.put("value", "value-" + cnt);
                 cnt += 1;
-                sendFutures.add(sendMessageAsync(TEST_TOPIC_0, partition, key, value));
+                sendFutures.add(sendMessageAsync(topicName, partition, key, value));
             }
         }
         producer.flush();
@@ -165,10 +164,10 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
         Thread.sleep(OFFSET_FLUSH_INTERVAL_MS * 2);
 
         final List<String> expectedBlobs = List.of(
-                getBlobName(0, 0, compression),
-                getBlobName(1, 0, compression),
-                getBlobName(2, 0, compression),
-                getBlobName(3, 0, compression));
+            getBlobName(topicName, 0, 0, compression),
+            getBlobName(topicName, 1, 0, compression),
+            getBlobName(topicName, 2, 0, compression),
+            getBlobName(topicName, 3, 0, compression));
         final Map<String, List<GenericRecord>> blobContents = new HashMap<>();
         for (final String blobName : expectedBlobs) {
             assertTrue(testBucketAccessor.doesObjectExist(blobName));
@@ -185,7 +184,7 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
             for (int partition = 0; partition < 4; partition++) {
                 final var name = "user-" + cnt;
                 final var value = "value-" + cnt;
-                final String blobName = getBlobName(partition, 0, "none");
+                final String blobName = getBlobName(topicName, partition, 0, "none");
                 final GenericRecord record = blobContents.get(blobName).get(i);
                 final var expectedKey = "key-" + cnt;
                 final var expectedValue = "{\"name\": \"" + name + "\", \"value\": \"" + value + "\"}";
@@ -200,16 +199,17 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
     }
 
     @Test
-    final void valueComplexType(@TempDir final Path tmpDir)
-            throws ExecutionException, InterruptedException, IOException {
+    final void valueComplexType(@TempDir final Path tmpDir, final TestInfo testInfo)
+        throws ExecutionException, InterruptedException, IOException {
+        final var topicName = IntegrationBase.topicName(testInfo);
         final String compression = "none";
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression));
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression), topicName);
         connectorConfig.put("format.output.fields", "value");
         connectorConfig.put("format.output.fields.value.encoding", "none");
         connectRunner.createConnector(connectorConfig);
 
         final Schema valueSchema =
-                SchemaBuilder.record("value")
+            SchemaBuilder.record("value")
                         .fields()
                         .name("name").type().stringType().noDefault()
                         .name("value").type().stringType().noDefault()
@@ -224,7 +224,7 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
                 value.put("name", "user-" + cnt);
                 value.put("value", "value-" + cnt);
                 cnt += 1;
-                sendFutures.add(sendMessageAsync(TEST_TOPIC_0, partition, key, value));
+                sendFutures.add(sendMessageAsync(topicName, partition, key, value));
             }
         }
         producer.flush();
@@ -236,10 +236,10 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
         Thread.sleep(OFFSET_FLUSH_INTERVAL_MS * 2);
 
         final List<String> expectedBlobs = List.of(
-                getBlobName(0, 0, compression),
-                getBlobName(1, 0, compression),
-                getBlobName(2, 0, compression),
-                getBlobName(3, 0, compression));
+            getBlobName(topicName, 0, 0, compression),
+            getBlobName(topicName, 1, 0, compression),
+            getBlobName(topicName, 2, 0, compression),
+            getBlobName(topicName, 3, 0, compression));
         final Map<String, List<GenericRecord>> blobContents = new HashMap<>();
         for (final String blobName : expectedBlobs) {
             final var records =
@@ -254,7 +254,7 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
             for (int partition = 0; partition < 4; partition++) {
                 final var name = "user-" + cnt;
                 final var value = "value-" + cnt;
-                final String blobName = getBlobName(partition, 0, "none");
+                final String blobName = getBlobName(topicName, partition, 0, "none");
                 final var record = blobContents.get(blobName).get(i);
                 final var avroRecord = (GenericRecord) record.get("value");
                 assertEquals(name, avroRecord.get("name").toString());
@@ -265,16 +265,17 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
     }
 
     @Test
-    final void schemaChanged(@TempDir final Path tmpDir)
-            throws ExecutionException, InterruptedException, IOException {
+    final void schemaChanged(@TempDir final Path tmpDir, final TestInfo testInfo)
+        throws ExecutionException, InterruptedException, IOException {
+        final var topicName = IntegrationBase.topicName(testInfo);
         final String compression = "none";
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression));
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression), topicName);
         connectorConfig.put("format.output.fields", "value");
         connectorConfig.put("format.output.fields.value.encoding", "none");
         connectRunner.createConnector(connectorConfig);
 
         final Schema valueSchema =
-                SchemaBuilder.record("value")
+            SchemaBuilder.record("value")
                         .fields()
                         .name("name").type().stringType().noDefault()
                         .name("value").type().stringType().noDefault()
@@ -307,7 +308,7 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
                 }
                 expectedRecords.add(value.toString());
                 cnt += 1;
-                sendFutures.add(sendMessageAsync(TEST_TOPIC_0, partition, key, value));
+                sendFutures.add(sendMessageAsync(topicName, partition, key, value));
             }
         }
         producer.flush();
@@ -319,14 +320,14 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
         Thread.sleep(OFFSET_FLUSH_INTERVAL_MS * 2);
 
         final List<String> expectedBlobs = Arrays.asList(
-                getBlobName(0, 0, compression),
-                getBlobName(0, 5, compression),
-                getBlobName(1, 0, compression),
-                getBlobName(1, 5, compression),
-                getBlobName(2, 0, compression),
-                getBlobName(2, 5, compression),
-                getBlobName(3, 0, compression),
-                getBlobName(3, 5, compression)
+            getBlobName(topicName, 0, 0, compression),
+            getBlobName(topicName, 0, 5, compression),
+            getBlobName(topicName, 1, 0, compression),
+            getBlobName(topicName, 1, 5, compression),
+            getBlobName(topicName, 2, 0, compression),
+            getBlobName(topicName, 2, 5, compression),
+            getBlobName(topicName, 3, 0, compression),
+            getBlobName(topicName, 3, 5, compression)
         );
         final var blobContents = new ArrayList<String>();
         for (final String blobName : expectedBlobs) {
@@ -343,14 +344,13 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
         );
     }
 
-    private KafkaProducer<String, GenericRecord> newProducer(final KafkaContainer kafka) {
-
+    private KafkaProducer<String, GenericRecord> newProducer() {
         final Map<String, Object> producerProps = new HashMap<>();
-        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-                "io.confluent.kafka.serializers.KafkaAvroSerializer");
+            "io.confluent.kafka.serializers.KafkaAvroSerializer");
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-                "io.confluent.kafka.serializers.KafkaAvroSerializer");
+            "io.confluent.kafka.serializers.KafkaAvroSerializer");
         producerProps.put("schema.registry.url", SCHEMA_REGISTRY.getSchemaRegistryUrl());
         return new KafkaProducer<>(producerProps);
     }
@@ -377,14 +377,14 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
         return config;
     }
 
-    private Map<String, String> awsSpecificConfig(final Map<String, String> config) {
+    private Map<String, String> awsSpecificConfig(final Map<String, String> config, final String topicName) {
         config.put("connector.class", AivenKafkaConnectS3SinkConnector.class.getName());
         config.put("aws.access.key.id", S3_ACCESS_KEY_ID);
         config.put("aws.secret.access.key", S3_SECRET_ACCESS_KEY);
         config.put("aws.s3.endpoint", s3Endpoint);
         config.put("aws.s3.bucket.name", TEST_BUCKET_NAME);
         config.put("aws.s3.prefix", s3Prefix);
-        config.put("topics", TEST_TOPIC_0);
+        config.put("topics", topicName);
         config.put("key.converter.schema.registry.url", SCHEMA_REGISTRY.getSchemaRegistryUrl());
         config.put("value.converter.schema.registry.url", SCHEMA_REGISTRY.getSchemaRegistryUrl());
         config.put("tasks.max", "1");
@@ -392,8 +392,9 @@ class AvroParquetIntegrationTest implements KafkaIntegrationBase {
     }
 
     // WARN: different from GCS
-    private String getBlobName(final int partition, final int startOffset, final String compression) {
-        final String result = String.format("%s%s-%d-%020d", s3Prefix, TEST_TOPIC_0, partition, startOffset);
+    private String getBlobName(final String topicName, final int partition, final int startOffset,
+                               final String compression) {
+        final String result = String.format("%s%s-%d-%020d", s3Prefix, topicName, partition, startOffset);
         return result + CompressionType.forName(compression).extension();
     }
 

--- a/src/integration-test/java/io/aiven/kafka/connect/IntegrationBase.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/IntegrationBase.java
@@ -23,25 +23,50 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.common.errors.TopicExistsException;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.github.dockerjava.api.model.Ulimit;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.TestInfo;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
 
+public interface IntegrationBase {
 
-public interface KafkaIntegrationBase {
+    static LocalStackContainer createS3Container() {
+        return new LocalStackContainer(
+            DockerImageName.parse("localstack/localstack:2.0.2")
+        ).withServices(LocalStackContainer.Service.S3);
+    }
 
-    String TEST_TOPIC_0 = "test-topic-0";
-
-    String TEST_TOPIC_1 = "test-topic-1";
+    static AmazonS3 createS3Client(final LocalStackContainer localStackContainer) {
+        return AmazonS3ClientBuilder
+            .standard()
+            .withEndpointConfiguration(
+                new AwsClientBuilder.EndpointConfiguration(
+                    localStackContainer.getEndpointOverride(LocalStackContainer.Service.S3).toString(),
+                    localStackContainer.getRegion()
+                )
+            )
+            .withCredentials(
+                new AWSStaticCredentialsProvider(
+                    new BasicAWSCredentials(localStackContainer.getAccessKey(), localStackContainer.getSecretKey())
+                )
+            )
+            .build();
+    }
 
     default AdminClient newAdminClient(final KafkaContainer kafka) {
         final Properties adminClientConfig = new Properties();
@@ -50,8 +75,8 @@ public interface KafkaIntegrationBase {
     }
 
     default ConnectRunner newConnectRunner(final KafkaContainer kafka,
-                                                  final File pluginDir,
-                                                  final int offsetFlushIntervalMs) {
+                                           final File pluginDir,
+                                           final int offsetFlushIntervalMs) {
         return new ConnectRunner(pluginDir, kafka.getBootstrapServers(), offsetFlushIntervalMs);
     }
 
@@ -84,35 +109,18 @@ public interface KafkaIntegrationBase {
             );
     }
 
-    static void recreateTopics(final AdminClient adminClient) throws InterruptedException, ExecutionException {
-        final var topics = List.of(TEST_TOPIC_0, TEST_TOPIC_1);
-        // to reuse the same container
-        try {
-            adminClient.deleteTopics(topics).all().get();
-        } catch (final ExecutionException e) {
-            if (!(e.getCause() instanceof UnknownTopicOrPartitionException)) { // else first exec
-                throw e;
-            }
-        }
-        Awaitility.await().atMost(Duration.ofSeconds(30)).until(() -> adminClient.listTopics().names().get()
-            .stream()
-            .noneMatch(topics::contains));
-        final NewTopic newTopic0 = new NewTopic(TEST_TOPIC_0, 4, (short) 1);
-        final NewTopic newTopic1 = new NewTopic(TEST_TOPIC_1, 4, (short) 1);
-        Awaitility.await().atMost(Duration.ofSeconds(30)).until(() -> {
-            try {
-                adminClient.createTopics(List.of(newTopic0, newTopic1)).all().get();
-                return true;
-            } catch (final ExecutionException e) {
-                if (!(e.getCause() instanceof TopicExistsException)) { // else first exec
-                    e.printStackTrace();
-                }
-            }
-            return false;
-        });
+    static String topicName(final TestInfo testInfo) {
+        return testInfo.getTestMethod().get().getName() + "-" + testInfo.getDisplayName().hashCode();
     }
 
-    static void waitForRunningContainer(final Container kafka) {
+    static void recreateTopics(final AdminClient adminClient, final List<String> topicNames)
+        throws ExecutionException, InterruptedException {
+        adminClient.createTopics(
+                topicNames.stream().map(s -> new NewTopic(s, 4, (short) 1)).collect(Collectors.toList())).all()
+            .get();
+    }
+
+    static void waitForRunningContainer(final Container<?> kafka) {
         Awaitility.await().atMost(Duration.ofMinutes(1)).until(kafka::isRunning);
     }
 }

--- a/src/integration-test/java/io/aiven/kafka/connect/IntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/IntegrationTest.java
@@ -45,10 +45,6 @@ import io.aiven.kafka.connect.s3.testutils.IndexesToString;
 import io.aiven.kafka.connect.s3.testutils.KeyValueGenerator;
 import io.aiven.kafka.connect.s3.testutils.KeyValueMessage;
 
-import cloud.localstack.Localstack;
-import cloud.localstack.awssdkv1.TestUtils;
-import cloud.localstack.docker.LocalstackDockerExtension;
-import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 import com.amazonaws.services.s3.AmazonS3;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -59,10 +55,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -73,10 +70,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(LocalstackDockerExtension.class)
-@LocalstackDockerProperties(services = {"s3"})
 @Testcontainers
-final class IntegrationTest implements KafkaIntegrationBase {
+final class IntegrationTest implements IntegrationBase {
     private static final String S3_ACCESS_KEY_ID = "test-key-id0";
     private static final String S3_SECRET_ACCESS_KEY = "test_secret_key0";
     private static final String TEST_BUCKET_NAME = "test-bucket0";
@@ -91,7 +86,9 @@ final class IntegrationTest implements KafkaIntegrationBase {
     private static File pluginDir;
 
     @Container
-    private static final KafkaContainer KAFKA = KafkaIntegrationBase.createKafkaContainer();
+    public static final LocalStackContainer LOCALSTACK = IntegrationBase.createS3Container();
+    @Container
+    private static final KafkaContainer KAFKA = IntegrationBase.createKafkaContainer();
     private AdminClient adminClient;
     private KafkaProducer<byte[], byte[]> producer;
     private ConnectRunner connectRunner;
@@ -101,31 +98,33 @@ final class IntegrationTest implements KafkaIntegrationBase {
         s3Prefix = COMMON_PREFIX
             + ZonedDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + "/";
 
-        final AmazonS3 s3 = TestUtils.getClientS3();
-        s3Endpoint = Localstack.INSTANCE.getEndpointS3();
+        final AmazonS3 s3 = IntegrationBase.createS3Client(LOCALSTACK);
+        s3Endpoint = LOCALSTACK.getEndpoint().toString();
         testBucketAccessor = new BucketAccessor(s3, TEST_BUCKET_NAME);
 
-        pluginDir = KafkaIntegrationBase.getPluginDir();
-        KafkaIntegrationBase.extractConnectorPlugin(pluginDir);
+        pluginDir = IntegrationBase.getPluginDir();
+        IntegrationBase.extractConnectorPlugin(pluginDir);
 
-        KafkaIntegrationBase.waitForRunningContainer(KAFKA);
+        IntegrationBase.waitForRunningContainer(KAFKA);
     }
 
     @BeforeEach
-    void setUp() throws ExecutionException, InterruptedException {
+    void setUp(final TestInfo testInfo) throws ExecutionException, InterruptedException {
         testBucketAccessor.createBucket();
 
         adminClient = newAdminClient(KAFKA);
-        producer = newProducer(KAFKA);
+        producer = newProducer();
 
-        KafkaIntegrationBase.recreateTopics(adminClient);
+        final var topicName = IntegrationBase.topicName(testInfo);
+        final var topics = List.of(topicName);
+        IntegrationBase.recreateTopics(adminClient, topics);
 
         connectRunner = newConnectRunner(KAFKA, pluginDir, OFFSET_FLUSH_INTERVAL_MS);
         connectRunner.start();
     }
 
     @AfterEach
-    final void tearDown() {
+    void tearDown() {
         testBucketAccessor.removeBucket();
         connectRunner.stop();
         adminClient.close();
@@ -136,8 +135,10 @@ final class IntegrationTest implements KafkaIntegrationBase {
 
     @ParameterizedTest
     @ValueSource(strings = {"none", "gzip", "snappy", "zstd"})
-    final void basicTest(final String compression) throws ExecutionException, InterruptedException, IOException {
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME));
+    void basicTest(final String compression, final TestInfo testInfo)
+        throws ExecutionException, InterruptedException, IOException {
+        final var topicName = IntegrationBase.topicName(testInfo);
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME), topicName);
         connectorConfig.put("format.output.fields", "key,value");
         connectorConfig.put("file.compression.type", compression);
         connectorConfig.put("aws.s3.prefix", s3Prefix);
@@ -148,7 +149,7 @@ final class IntegrationTest implements KafkaIntegrationBase {
         final IndexesToString valueGen = (partition, epoch, currIdx) -> "value-" + currIdx;
 
         for (final KeyValueMessage msg : new KeyValueGenerator(4, 10, keyGen, valueGen)) {
-            sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, msg.partition, msg.key, msg.value));
+            sendFutures.add(sendMessageAsync(producer, topicName, msg.partition, msg.key, msg.value));
         }
 
         producer.flush();
@@ -160,10 +161,10 @@ final class IntegrationTest implements KafkaIntegrationBase {
         Thread.sleep(OFFSET_FLUSH_INTERVAL_MS * 2);
 
         final List<String> expectedBlobs = Arrays.asList(
-            getOldBlobName(0, 0, compression),
-            getOldBlobName(1, 0, compression),
-            getOldBlobName(2, 0, compression),
-            getOldBlobName(3, 0, compression));
+            getOldBlobName(topicName, 0, 0, compression),
+            getOldBlobName(topicName, 1, 0, compression),
+            getOldBlobName(topicName, 2, 0, compression),
+            getOldBlobName(topicName, 3, 0, compression));
         for (final String blobName : expectedBlobs) {
             assertTrue(testBucketAccessor.doesObjectExist(blobName));
         }
@@ -178,7 +179,7 @@ final class IntegrationTest implements KafkaIntegrationBase {
         }
 
         for (final KeyValueMessage msg : new KeyValueGenerator(4, 10, keyGen, valueGen)) {
-            final String blobName = getOldBlobName(msg.partition, 0, compression);
+            final String blobName = getOldBlobName(topicName, msg.partition, 0, compression);
             final String actualLine = blobContents.get(blobName).get(msg.epoch);
             final String expectedLine = msg.key + "," + msg.value;
             assertEquals(expectedLine, actualLine);
@@ -187,10 +188,11 @@ final class IntegrationTest implements KafkaIntegrationBase {
 
     @ParameterizedTest
     @ValueSource(strings = {"none", "gzip", "snappy", "zstd"})
-    final void groupByTimestampVariable(final String compression) throws ExecutionException,
-                                                                         InterruptedException,
-                                                                         IOException {
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME));
+    void groupByTimestampVariable(final String compression, final TestInfo testInfo) throws ExecutionException,
+        InterruptedException,
+        IOException {
+        final var topicName = IntegrationBase.topicName(testInfo);
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME), topicName);
         connectorConfig.put("format.output.fields", "key,value");
         connectorConfig.put("file.compression.type", compression);
         connectorConfig.put(
@@ -201,11 +203,11 @@ final class IntegrationTest implements KafkaIntegrationBase {
         connectRunner.createConnector(connectorConfig);
 
         final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
-        sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, 0, "key-0", "value-0"));
-        sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, 0, "key-1", "value-1"));
-        sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, 0, "key-2", "value-2"));
-        sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, 1, "key-3", "value-3"));
-        sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, 3, "key-4", "value-4"));
+        sendFutures.add(sendMessageAsync(producer, topicName, 0, "key-0", "value-0"));
+        sendFutures.add(sendMessageAsync(producer, topicName, 0, "key-1", "value-1"));
+        sendFutures.add(sendMessageAsync(producer, topicName, 0, "key-2", "value-2"));
+        sendFutures.add(sendMessageAsync(producer, topicName, 1, "key-3", "value-3"));
+        sendFutures.add(sendMessageAsync(producer, topicName, 3, "key-4", "value-4"));
 
         producer.flush();
         for (final Future<RecordMetadata> sendFuture : sendFutures) {
@@ -217,16 +219,16 @@ final class IntegrationTest implements KafkaIntegrationBase {
 
         final Map<String, String[]> expectedBlobsAndContent = new HashMap<>();
         expectedBlobsAndContent.put(
-            getTimestampBlobName(0, 0),
-            new String[]{"key-0,value-0", "key-1,value-1", "key-2,value-2"}
+            getTimestampBlobName(topicName, 0, 0),
+            new String[] {"key-0,value-0", "key-1,value-1", "key-2,value-2"}
         );
         expectedBlobsAndContent.put(
-            getTimestampBlobName(1, 0),
-            new String[]{"key-3,value-3"}
+            getTimestampBlobName(topicName, 1, 0),
+            new String[] {"key-3,value-3"}
         );
         expectedBlobsAndContent.put(
-            getTimestampBlobName(3, 0),
-            new String[]{"key-4,value-4"}
+            getTimestampBlobName(topicName, 3, 0),
+            new String[] {"key-4,value-4"}
         );
 
         final List<String> expectedBlobs =
@@ -235,7 +237,6 @@ final class IntegrationTest implements KafkaIntegrationBase {
             assertTrue(testBucketAccessor.doesObjectExist(blobName));
         }
 
-        final Map<String, List<String>> blobContents = new HashMap<>();
         for (final String blobName : expectedBlobs) {
             final List<String> blobContent =
                 testBucketAccessor.readAndDecodeLines(blobName, compression, 0, 1).stream()
@@ -246,12 +247,12 @@ final class IntegrationTest implements KafkaIntegrationBase {
         }
     }
 
-    private String getTimestampBlobName(final int partition, final int startOffset) {
+    private String getTimestampBlobName(final String topicName, final int partition, final int startOffset) {
         final ZonedDateTime time = ZonedDateTime.now(ZoneId.of("UTC"));
         return String.format(
             "%s%s-%d-%d-%s-%s-%s",
             s3Prefix,
-            TEST_TOPIC_0,
+            topicName,
             partition,
             startOffset,
             time.format(DateTimeFormatter.ofPattern("yyyy")),
@@ -262,9 +263,10 @@ final class IntegrationTest implements KafkaIntegrationBase {
 
     @ParameterizedTest
     @ValueSource(strings = {"none", "gzip", "snappy", "zstd"})
-    final void oneFilePerRecordWithPlainValues(final String compression)
+    void oneFilePerRecordWithPlainValues(final String compression, final TestInfo testInfo)
         throws ExecutionException, InterruptedException, IOException {
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME));
+        final var topicName = IntegrationBase.topicName(testInfo);
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME), topicName);
         connectorConfig.put("format.output.fields", "value");
         connectorConfig.put("file.compression.type", compression);
         connectorConfig.put("format.output.fields.value.encoding", "none");
@@ -273,11 +275,11 @@ final class IntegrationTest implements KafkaIntegrationBase {
 
         final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
 
-        sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, 0, "key-0", "value-0"));
-        sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, 0, "key-1", "value-1"));
-        sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, 0, "key-2", "value-2"));
-        sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, 1, "key-3", "value-3"));
-        sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, 3, "key-4", "value-4"));
+        sendFutures.add(sendMessageAsync(producer, topicName, 0, "key-0", "value-0"));
+        sendFutures.add(sendMessageAsync(producer, topicName, 0, "key-1", "value-1"));
+        sendFutures.add(sendMessageAsync(producer, topicName, 0, "key-2", "value-2"));
+        sendFutures.add(sendMessageAsync(producer, topicName, 1, "key-3", "value-3"));
+        sendFutures.add(sendMessageAsync(producer, topicName, 3, "key-4", "value-4"));
 
         producer.flush();
         for (final Future<RecordMetadata> sendFuture : sendFutures) {
@@ -288,11 +290,11 @@ final class IntegrationTest implements KafkaIntegrationBase {
         Thread.sleep(OFFSET_FLUSH_INTERVAL_MS * 2);
 
         final Map<String, String> expectedBlobsAndContent = new HashMap<>();
-        expectedBlobsAndContent.put(getNewBlobName(0, 0, compression), "value-0");
-        expectedBlobsAndContent.put(getNewBlobName(0, 1, compression), "value-1");
-        expectedBlobsAndContent.put(getNewBlobName(0, 2, compression), "value-2");
-        expectedBlobsAndContent.put(getNewBlobName(1, 0, compression), "value-3");
-        expectedBlobsAndContent.put(getNewBlobName(3, 0, compression), "value-4");
+        expectedBlobsAndContent.put(getNewBlobName(topicName, 0, 0, compression), "value-0");
+        expectedBlobsAndContent.put(getNewBlobName(topicName, 0, 1, compression), "value-1");
+        expectedBlobsAndContent.put(getNewBlobName(topicName, 0, 2, compression), "value-2");
+        expectedBlobsAndContent.put(getNewBlobName(topicName, 1, 0, compression), "value-3");
+        expectedBlobsAndContent.put(getNewBlobName(topicName, 3, 0, compression), "value-4");
         final List<String> expectedBlobs =
             expectedBlobsAndContent.keySet().stream().sorted().collect(Collectors.toList());
 
@@ -311,8 +313,13 @@ final class IntegrationTest implements KafkaIntegrationBase {
 
     @ParameterizedTest
     @ValueSource(strings = {"none", "gzip", "snappy", "zstd"})
-    final void groupByKey(final String compression) throws ExecutionException, InterruptedException, IOException {
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME));
+    void groupByKey(final String compression, final TestInfo testInfo)
+        throws ExecutionException, InterruptedException, IOException {
+        final var topicName0 = IntegrationBase.topicName(testInfo);
+        final var topicName1 = IntegrationBase.topicName(testInfo) + "_1";
+        IntegrationBase.recreateTopics(adminClient, List.of(topicName1));
+        final Map<String, String> connectorConfig =
+            awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME), List.of(topicName0, topicName1));
         final CompressionType compressionType = CompressionType.forName(compression);
         connectorConfig.put("key.converter", "org.apache.kafka.connect.storage.StringConverter");
         connectorConfig.put("format.output.fields", "key,value");
@@ -322,10 +329,10 @@ final class IntegrationTest implements KafkaIntegrationBase {
 
         final Map<TopicPartition, List<String>> keysPerTopicPartition = new HashMap<>();
         keysPerTopicPartition.put(
-            new TopicPartition(TEST_TOPIC_0, 0), Arrays.asList("key-0", "key-1", "key-2", "key-3"));
-        keysPerTopicPartition.put(new TopicPartition(TEST_TOPIC_0, 1), Arrays.asList("key-4", "key-5", "key-6"));
-        keysPerTopicPartition.put(new TopicPartition(TEST_TOPIC_1, 0), Arrays.asList(null, "key-7"));
-        keysPerTopicPartition.put(new TopicPartition(TEST_TOPIC_1, 1), Arrays.asList("key-8"));
+            new TopicPartition(topicName0, 0), Arrays.asList("key-0", "key-1", "key-2", "key-3"));
+        keysPerTopicPartition.put(new TopicPartition(topicName0, 1), Arrays.asList("key-4", "key-5", "key-6"));
+        keysPerTopicPartition.put(new TopicPartition(topicName1, 0), Arrays.asList(null, "key-7"));
+        keysPerTopicPartition.put(new TopicPartition(topicName1, 1), Arrays.asList("key-8"));
 
         final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
         final Map<String, String> lastValuePerKey = new HashMap<>();
@@ -382,8 +389,9 @@ final class IntegrationTest implements KafkaIntegrationBase {
     }
 
     @Test
-    final void jsonlOutputTest() throws ExecutionException, InterruptedException, IOException {
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME));
+    void jsonlOutputTest(final TestInfo testInfo) throws ExecutionException, InterruptedException, IOException {
+        final var topicName = IntegrationBase.topicName(testInfo);
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME), topicName);
         final String compression = "none";
         final String contentType = "jsonl";
         connectorConfig.put("format.output.fields", "key,value");
@@ -403,7 +411,7 @@ final class IntegrationTest implements KafkaIntegrationBase {
                 final String value = "[{" + "\"name\":\"user-" + cnt + "\"}]";
                 cnt += 1;
 
-                sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, partition, key, value));
+                sendFutures.add(sendMessageAsync(producer, topicName, partition, key, value));
             }
         }
         producer.flush();
@@ -415,10 +423,10 @@ final class IntegrationTest implements KafkaIntegrationBase {
         Thread.sleep(OFFSET_FLUSH_INTERVAL_MS * 2);
 
         final List<String> expectedBlobs = Arrays.asList(
-            getNewBlobName(0, 0, compression),
-            getNewBlobName(1, 0, compression),
-            getNewBlobName(2, 0, compression),
-            getNewBlobName(3, 0, compression));
+            getNewBlobName(topicName, 0, 0, compression),
+            getNewBlobName(topicName, 1, 0, compression),
+            getNewBlobName(topicName, 2, 0, compression),
+            getNewBlobName(topicName, 3, 0, compression));
         for (final String blobName : expectedBlobs) {
             assertTrue(testBucketAccessor.doesObjectExist(blobName));
         }
@@ -436,7 +444,7 @@ final class IntegrationTest implements KafkaIntegrationBase {
                 final String value = "[{" + "\"name\":\"user-" + cnt + "\"}]";
                 cnt += 1;
 
-                final String blobName = getNewBlobName(partition, 0, "none");
+                final String blobName = getNewBlobName(topicName, partition, 0, "none");
                 final String actualLine = blobContents.get(blobName).get(i);
                 final String expectedLine = "{\"value\":" + value + ",\"key\":\"" + key + "\"}";
                 assertEquals(expectedLine, actualLine);
@@ -445,9 +453,10 @@ final class IntegrationTest implements KafkaIntegrationBase {
     }
 
     @Test
-    final void jsonOutput() throws ExecutionException, InterruptedException, IOException {
-        final var faultyProxy = enableFaultyProxy();
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME));
+    void jsonOutput(final TestInfo testInfo) throws ExecutionException, InterruptedException, IOException {
+        final var topicName = IntegrationBase.topicName(testInfo);
+        final var faultyProxy = enableFaultyProxy(topicName);
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(CONNECTOR_NAME), topicName);
         connectorConfig.put("aws.s3.endpoint", faultyProxy.baseUrl());
         final String compression = "none";
         final String contentType = "json";
@@ -470,7 +479,7 @@ final class IntegrationTest implements KafkaIntegrationBase {
             (partition, epoch, currIdx) -> "[{" + "\"name\":\"user-" + currIdx + "\"}]";
 
         for (final KeyValueMessage msg : new KeyValueGenerator(numPartitions, numEpochs, keyGen, valueGen)) {
-            sendFutures.add(sendMessageAsync(producer, TEST_TOPIC_0, msg.partition, msg.key, msg.value));
+            sendFutures.add(sendMessageAsync(producer, topicName, msg.partition, msg.key, msg.value));
         }
 
         producer.flush();
@@ -483,10 +492,10 @@ final class IntegrationTest implements KafkaIntegrationBase {
         }
 
         final List<String> expectedBlobs = Arrays.asList(
-            getNewBlobName(0, 0, compression),
-            getNewBlobName(1, 0, compression),
-            getNewBlobName(2, 0, compression),
-            getNewBlobName(3, 0, compression));
+            getNewBlobName(topicName, 0, 0, compression),
+            getNewBlobName(topicName, 1, 0, compression),
+            getNewBlobName(topicName, 2, 0, compression),
+            getNewBlobName(topicName, 3, 0, compression));
         for (final String blobName : expectedBlobs) {
             assertTrue(testBucketAccessor.doesObjectExist(blobName));
         }
@@ -500,7 +509,7 @@ final class IntegrationTest implements KafkaIntegrationBase {
 
         // Each blob must be a JSON array.
         for (final KeyValueMessage msg : new KeyValueGenerator(numPartitions, numEpochs, keyGen, valueGen)) {
-            final String blobName = getNewBlobName(msg.partition, 0, compression);
+            final String blobName = getNewBlobName(topicName, msg.partition, 0, compression);
             final List<String> blobContent = blobContents.get(blobName);
             assertEquals("[", blobContent.get(0));
             assertEquals("]", blobContent.get(blobContent.size() - 1));
@@ -514,14 +523,14 @@ final class IntegrationTest implements KafkaIntegrationBase {
         }
     }
 
-    private static WireMockServer enableFaultyProxy() {
+    private static WireMockServer enableFaultyProxy(final String topicName) {
         System.setProperty(DISABLE_CERT_CHECKING_SYSTEM_PROPERTY, "true");
         final WireMockServer wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicHttpsPort());
         wireMockServer.start();
         wireMockServer
             .addStubMapping(WireMock.request(RequestMethod.ANY.getName(), UrlPattern.ANY)
                 .willReturn(aResponse().proxiedFrom(s3Endpoint)).build());
-        final String urlPathPattern = "/" + TEST_BUCKET_NAME + "/" + TEST_TOPIC_0 + "([\\-0-9]+)";
+        final String urlPathPattern = "/" + TEST_BUCKET_NAME + "/" + topicName + "([\\-0-9]+)";
         wireMockServer
             .addStubMapping(WireMock.request(RequestMethod.POST.getName(),
                     UrlPattern.fromOneOf(null, null, null, urlPathPattern))
@@ -537,9 +546,9 @@ final class IntegrationTest implements KafkaIntegrationBase {
         return wireMockServer;
     }
 
-    private KafkaProducer<byte[], byte[]> newProducer(final KafkaContainer kafka) {
+    private KafkaProducer<byte[], byte[]> newProducer() {
         final Map<String, Object> producerProps = new HashMap<>();
-        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
             "org.apache.kafka.common.serialization.ByteArraySerializer");
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
@@ -568,24 +577,30 @@ final class IntegrationTest implements KafkaIntegrationBase {
         return config;
     }
 
-    private Map<String, String> awsSpecificConfig(final Map<String, String> config) {
+    private Map<String, String> awsSpecificConfig(final Map<String, String> config, final String topicName) {
+        return awsSpecificConfig(config, List.of(topicName));
+    }
+
+    private Map<String, String> awsSpecificConfig(final Map<String, String> config, final List<String> topicNames) {
         config.put("connector.class", AivenKafkaConnectS3SinkConnector.class.getName());
         config.put("aws.access.key.id", S3_ACCESS_KEY_ID);
         config.put("aws.secret.access.key", S3_SECRET_ACCESS_KEY);
         config.put("aws.s3.endpoint", s3Endpoint);
         config.put("aws.s3.bucket.name", TEST_BUCKET_NAME);
-        config.put("topics", TEST_TOPIC_0 + "," + TEST_TOPIC_1);
+        config.put("topics", String.join(",", topicNames));
         return config;
     }
 
     // WARN: different from GCS
-    private String getOldBlobName(final int partition, final int startOffset, final String compression) {
-        final String result = String.format("%s%s-%d-%020d", s3Prefix, TEST_TOPIC_0, partition, startOffset);
+    private String getOldBlobName(final String topicName, final int partition, final int startOffset,
+                                  final String compression) {
+        final String result = String.format("%s%s-%d-%020d", s3Prefix, topicName, partition, startOffset);
         return result + CompressionType.forName(compression).extension();
     }
 
-    private String getNewBlobName(final int partition, final int startOffset, final String compression) {
-        final String result = String.format("%s-%d-%d", TEST_TOPIC_0, partition, startOffset);
+    private String getNewBlobName(final String topicName, final int partition, final int startOffset,
+                                  final String compression) {
+        final String result = String.format("%s-%d-%d", topicName, partition, startOffset);
         return result + CompressionType.forName(compression).extension();
     }
 

--- a/src/integration-test/java/io/aiven/kafka/connect/ParquetIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/ParquetIntegrationTest.java
@@ -20,8 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -41,22 +39,18 @@ import io.aiven.kafka.connect.common.config.CompressionType;
 import io.aiven.kafka.connect.s3.AivenKafkaConnectS3SinkConnector;
 import io.aiven.kafka.connect.s3.testutils.BucketAccessor;
 
-import cloud.localstack.Localstack;
-import cloud.localstack.ServiceName;
-import cloud.localstack.awssdkv1.TestUtils;
-import cloud.localstack.docker.LocalstackDockerExtension;
-import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 import com.amazonaws.services.s3.AmazonS3;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -66,10 +60,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(LocalstackDockerExtension.class)
-@LocalstackDockerProperties(services = {ServiceName.S3})
 @Testcontainers
-final class ParquetIntegrationTest implements KafkaIntegrationBase {
+final class ParquetIntegrationTest implements IntegrationBase {
 
     private static final String S3_ACCESS_KEY_ID = "test-key-id0";
 
@@ -79,19 +71,18 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
 
     private static final String CONNECTOR_NAME = "aiven-s3-sink-connector";
 
-    private static final String COMMON_PREFIX = "s3-connector-for-apache-kafka-test-";
-
     private static final int OFFSET_FLUSH_INTERVAL_MS = 5000;
 
     private static String s3Endpoint;
-    private static String s3Prefix;
     private static BucketAccessor testBucketAccessor;
     private static File pluginDir;
     @TempDir
     Path tmpDir;
 
     @Container
-    private static final KafkaContainer KAFKA = KafkaIntegrationBase.createKafkaContainer();
+    public static final LocalStackContainer LOCALSTACK = IntegrationBase.createS3Container();
+    @Container
+    private static final KafkaContainer KAFKA = IntegrationBase.createKafkaContainer();
 
     private AdminClient adminClient;
     private KafkaProducer<byte[], byte[]> producer;
@@ -99,27 +90,25 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
 
     @BeforeAll
     static void setUpAll() throws IOException, InterruptedException {
-        s3Prefix = COMMON_PREFIX
-                + ZonedDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + "/";
-
-        final AmazonS3 s3 = TestUtils.getClientS3();
-        s3Endpoint = Localstack.INSTANCE.getEndpointS3();
+        final AmazonS3 s3 = IntegrationBase.createS3Client(LOCALSTACK);
+        s3Endpoint = LOCALSTACK.getEndpoint().toString();
         testBucketAccessor = new BucketAccessor(s3, TEST_BUCKET_NAME);
 
-        pluginDir = KafkaIntegrationBase.getPluginDir();
-        KafkaIntegrationBase.extractConnectorPlugin(pluginDir);
+        pluginDir = IntegrationBase.getPluginDir();
+        IntegrationBase.extractConnectorPlugin(pluginDir);
 
-        KafkaIntegrationBase.waitForRunningContainer(KAFKA);
+        IntegrationBase.waitForRunningContainer(KAFKA);
     }
 
     @BeforeEach
-    void setUp() throws ExecutionException, InterruptedException {
+    void setUp(final TestInfo testInfo) throws ExecutionException, InterruptedException {
         testBucketAccessor.createBucket();
 
         adminClient = newAdminClient(KAFKA);
-        producer = newProducer(KAFKA);
+        producer = newProducer();
 
-        KafkaIntegrationBase.recreateTopics(adminClient);
+        final var topicName = IntegrationBase.topicName(testInfo);
+        IntegrationBase.recreateTopics(adminClient, List.of(topicName));
 
         connectRunner = newConnectRunner(KAFKA, pluginDir, OFFSET_FLUSH_INTERVAL_MS);
         connectRunner.start();
@@ -136,9 +125,9 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
         connectRunner.awaitStop();
     }
 
-    private KafkaProducer<byte[], byte[]> newProducer(final KafkaContainer kafka) {
+    private KafkaProducer<byte[], byte[]> newProducer() {
         final Map<String, Object> producerProps = new HashMap<>();
-        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
                 "org.apache.kafka.common.serialization.ByteArraySerializer");
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
@@ -147,10 +136,11 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
     }
 
     @Test
-    void allOutputFields()
-            throws ExecutionException, InterruptedException, IOException {
+    void allOutputFields(final TestInfo testInfo)
+        throws ExecutionException, InterruptedException, IOException {
+        final var topicName = IntegrationBase.topicName(testInfo);
         final var compression = "none";
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression));
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression), topicName);
         connectorConfig.put("format.output.fields", "key,value,offset,timestamp,headers");
         connectorConfig.put("format.output.fields.value.encoding", "none");
         connectorConfig.put("key.converter", "org.apache.kafka.connect.storage.StringConverter");
@@ -164,7 +154,7 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
                 final String key = "key-" + cnt;
                 final String value = "value-" + cnt;
                 cnt += 1;
-                sendFutures.add(sendMessageAsync(TEST_TOPIC_0, partition, key, value));
+                sendFutures.add(sendMessageAsync(topicName, partition, key, value));
             }
         }
         producer.flush();
@@ -178,10 +168,10 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
 
         final var blobContents = new HashMap<String, List<GenericRecord>>();
         final List<String> expectedBlobs = Arrays.asList(
-                getBlobName(0, 0, compression),
-                getBlobName(1, 0, compression),
-                getBlobName(2, 0, compression),
-                getBlobName(3, 0, compression));
+                getBlobName(topicName, 0, 0, compression),
+                getBlobName(topicName, 1, 0, compression),
+                getBlobName(topicName, 2, 0, compression),
+                getBlobName(topicName, 3, 0, compression));
         for (final String blobName : expectedBlobs) {
             assertTrue(testBucketAccessor.doesObjectExist(blobName));
             final var records =
@@ -197,7 +187,7 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
             for (int partition = 0; partition < 4; partition++) {
                 final var key = "key-" + cnt;
                 final var value = "value-" + cnt;
-                final String blobName = getBlobName(partition, 0, compression);
+                final String blobName = getBlobName(topicName, partition, 0, compression);
                 final var record = blobContents.get(blobName).get(i);
                 assertEquals(key, record.get("key").toString());
                 assertEquals(value, record.get("value").toString());
@@ -210,10 +200,11 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
     }
 
     @Test
-    void allOutputFieldsJsonValueAsString()
-            throws ExecutionException, InterruptedException, IOException {
+    void allOutputFieldsJsonValueAsString(final TestInfo testInfo)
+        throws ExecutionException, InterruptedException, IOException {
+        final var topicName = IntegrationBase.topicName(testInfo);
         final var compression = "none";
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression));
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression), topicName);
         connectorConfig.put("format.output.fields", "key,value,offset,timestamp,headers");
         connectorConfig.put("format.output.fields.value.encoding", "none");
         connectorConfig.put("key.converter", "org.apache.kafka.connect.storage.StringConverter");
@@ -227,7 +218,7 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
                 final String key = "key-" + cnt;
                 final String value = "{\"name\": \"name-" + cnt + "\", \"value\": \"value-" + cnt + "\"}";
                 cnt += 1;
-                sendFutures.add(sendMessageAsync(TEST_TOPIC_0, partition, key, value));
+                sendFutures.add(sendMessageAsync(topicName, partition, key, value));
             }
         }
         producer.flush();
@@ -240,10 +231,10 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
 
         final var blobContents = new HashMap<String, List<GenericRecord>>();
         final List<String> expectedBlobs = Arrays.asList(
-                getBlobName(0, 0, compression),
-                getBlobName(1, 0, compression),
-                getBlobName(2, 0, compression),
-                getBlobName(3, 0, compression));
+                getBlobName(topicName, 0, 0, compression),
+                getBlobName(topicName, 1, 0, compression),
+                getBlobName(topicName, 2, 0, compression),
+                getBlobName(topicName, 3, 0, compression));
         for (final String blobName : expectedBlobs) {
             assertTrue(testBucketAccessor.doesObjectExist(blobName));
             final var records =
@@ -259,7 +250,7 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
             for (int partition = 0; partition < 4; partition++) {
                 final var key = "key-" + cnt;
                 final var value = "{\"name\": \"name-" + cnt + "\", \"value\": \"value-" + cnt + "\"}";
-                final String blobName = getBlobName(partition, 0, compression);
+                final String blobName = getBlobName(topicName, partition, 0, compression);
                 final var record = blobContents.get(blobName).get(i);
                 assertEquals(key, record.get("key").toString());
                 assertEquals(value, record.get("value").toString());
@@ -273,10 +264,11 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
 
     @ParameterizedTest
     @CsvSource({"true, {\"value\": {\"name\": \"%s\"}} ", "false, {\"name\": \"%s\"}"})
-    void jsonValue(final String envelopeEnabled, final String expectedOutput)
-            throws ExecutionException, InterruptedException, IOException {
+    void jsonValue(final String envelopeEnabled, final String expectedOutput, final TestInfo testInfo)
+        throws ExecutionException, InterruptedException, IOException {
+        final var topicName = IntegrationBase.topicName(testInfo);
         final var compression = "none";
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression));
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression), topicName);
         connectorConfig.put("format.output.fields", "value");
         connectorConfig.put("format.output.envelope", envelopeEnabled);
         connectorConfig.put("format.output.fields.value.encoding", "none");
@@ -299,7 +291,7 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
                         );
                 cnt += 1;
 
-                sendFutures.add(sendMessageAsync(TEST_TOPIC_0, partition, key, value));
+                sendFutures.add(sendMessageAsync(topicName, partition, key, value));
             }
         }
         producer.flush();
@@ -312,10 +304,10 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
 
         final var blobContents = new HashMap<String, List<GenericRecord>>();
         final List<String> expectedBlobs = Arrays.asList(
-                getBlobName(0, 0, compression),
-                getBlobName(1, 0, compression),
-                getBlobName(2, 0, compression),
-                getBlobName(3, 0, compression));
+                getBlobName(topicName, 0, 0, compression),
+                getBlobName(topicName, 1, 0, compression),
+                getBlobName(topicName, 2, 0, compression),
+                getBlobName(topicName, 3, 0, compression));
         for (final String blobName : expectedBlobs) {
             assertTrue(testBucketAccessor.doesObjectExist(blobName));
             final var records =
@@ -330,7 +322,7 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
         for (int i = 0; i < 10; i++) {
             for (int partition = 0; partition < 4; partition++) {
                 final var name = "user-" + cnt;
-                final String blobName = getBlobName(partition, 0, compression);
+                final String blobName = getBlobName(topicName, partition, 0, compression);
                 final var record = blobContents.get(blobName).get(i);
                 final String expectedLine = String.format(expectedOutput, name);
                 assertEquals(expectedLine, record.toString());
@@ -340,10 +332,11 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
     }
 
     @Test
-    void schemaChanged()
-            throws ExecutionException, InterruptedException, IOException {
+    void schemaChanged(final TestInfo testInfo)
+        throws ExecutionException, InterruptedException, IOException {
+        final var topicName = IntegrationBase.topicName(testInfo);
         final var compression = "none";
-        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression));
+        final Map<String, String> connectorConfig = awsSpecificConfig(basicConnectorConfig(compression), topicName);
         connectorConfig.put("format.output.fields", "value");
         connectorConfig.put("format.output.fields.value.encoding", "none");
         connectorConfig.put("key.converter", "org.apache.kafka.connect.storage.StringConverter");
@@ -372,7 +365,7 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
                     value = String.format(jsonMessagePattern, jsonMessageNewSchema, payload);
                 }
                 expectedRecords.add(payload);
-                sendFutures.add(sendMessageAsync(TEST_TOPIC_0, partition, key, value));
+                sendFutures.add(sendMessageAsync(topicName, partition, key, value));
                 cnt += 1;
             }
         }
@@ -385,14 +378,14 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
         Thread.sleep(OFFSET_FLUSH_INTERVAL_MS * 2);
 
         final List<String> expectedBlobs = Arrays.asList(
-                getBlobName(0, 0, compression),
-                getBlobName(0, 5, compression),
-                getBlobName(1, 0, compression),
-                getBlobName(1, 5, compression),
-                getBlobName(2, 0, compression),
-                getBlobName(2, 5, compression),
-                getBlobName(3, 0, compression),
-                getBlobName(3, 5, compression)
+                getBlobName(topicName, 0, 0, compression),
+                getBlobName(topicName, 0, 5, compression),
+                getBlobName(topicName, 1, 0, compression),
+                getBlobName(topicName, 1, 5, compression),
+                getBlobName(topicName, 2, 0, compression),
+                getBlobName(topicName, 2, 5, compression),
+                getBlobName(topicName, 3, 0, compression),
+                getBlobName(topicName, 3, 5, compression)
         );
         final var blobContents = new ArrayList<String>();
         for (final String blobName : expectedBlobs) {
@@ -400,23 +393,27 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
             final var records =
                     ParquetUtils.readRecords(
                             tmpDir.resolve(Paths.get(blobName)),
-                            testBucketAccessor.readBytes(blobName)
+                        testBucketAccessor.readBytes(blobName)
                     );
             blobContents.addAll(records.stream().map(r -> r.get("value").toString()).collect(Collectors.toList()));
         }
         assertIterableEquals(
-                expectedRecords.stream().sorted().collect(Collectors.toList()),
-                blobContents.stream().sorted().collect(Collectors.toList())
+            expectedRecords.stream().sorted().collect(Collectors.toList()),
+            blobContents.stream().sorted().collect(Collectors.toList())
         );
     }
 
-    private Map<String, String> awsSpecificConfig(final Map<String, String> config) {
+    private Map<String, String> awsSpecificConfig(final Map<String, String> config, final String topicName) {
+        return awsSpecificConfig(config, List.of(topicName));
+    }
+
+    private Map<String, String> awsSpecificConfig(final Map<String, String> config, final List<String> topicNames) {
         config.put("connector.class", AivenKafkaConnectS3SinkConnector.class.getName());
         config.put("aws.access.key.id", S3_ACCESS_KEY_ID);
         config.put("aws.secret.access.key", S3_SECRET_ACCESS_KEY);
         config.put("aws.s3.endpoint", s3Endpoint);
         config.put("aws.s3.bucket.name", TEST_BUCKET_NAME);
-        config.put("topics", TEST_TOPIC_0 + "," + TEST_TOPIC_1);
+        config.put("topics", String.join(",", topicNames));
         return config;
     }
 
@@ -436,14 +433,15 @@ final class ParquetIntegrationTest implements KafkaIntegrationBase {
                                                     final String key,
                                                     final String value) {
         final ProducerRecord<byte[], byte[]> msg = new ProducerRecord<>(
-                topicName, partition,
-                key == null ? null : key.getBytes(),
-                value == null ? null : value.getBytes());
+            topicName, partition,
+            key == null ? null : key.getBytes(),
+            value == null ? null : value.getBytes());
         return producer.send(msg);
     }
 
-    private String getBlobName(final int partition, final int startOffset, final String compression) {
-        final String result = String.format("%s-%d-%d", TEST_TOPIC_0, partition, startOffset);
+    private String getBlobName(final String topicName, final int partition, final int startOffset,
+                               final String compression) {
+        final String result = String.format("%s-%d-%d", topicName, partition, startOffset);
         return result + CompressionType.forName(compression).extension();
     }
 


### PR DESCRIPTION
Integration tests were not run on workflows. When enabling them, they were flaky:

- As containers were created per test method (parametrized tests), Docker runtime eventually hit some IP related issues.
- Moving into single containers per test suite caused some runtime issues with shared topics.
- Mixing localstack with testcontainers as different runtimes  for the integration test caused issues. Moving all to testcontainers. 